### PR TITLE
Fix: Added start script in package.json and fix localhost port in README(FIXES GAZ-27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Ensure you have the following software installed:
    ```
 
 5. **View in browser:**
-   Open your web browser and navigate to `http://localhost:3000`
+   Open your web browser and navigate to `http://localhost:5173`
 
 ### How to Use
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "start": "vite",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",


### PR DESCRIPTION
**Problem**
The README documented `npm start` and `yarn start` to run the application, 
but the `package.json` had no `start` script defined, causing new contributors 
to get an error: `Missing script: "start"` when trying to run the app.
Additionally, the README referenced `http://localhost:3000`, but Vite uses 
port `5173` by default.
<img width="1440" height="900" alt="Screenshot 2026-04-19 at 5 56 06 PM" src="https://github.com/user-attachments/assets/39d7442c-9fb4-420f-878a-c49365184a21" />

**Solution**
Added `"start": "vite"` to the scripts in `package.json` so `npm start` works 
as documented. Updated the localhost port to `5173` to match Vite's default.

**Changes**
Added `"start": "vite"` script to `package.json`
Updated localhost port from `3000` to `5173` in `README.md`

**Testing**
Ran `npm start` successfully. Dev server started at `http://localhost:5173`.
<img width="1440" height="900" alt="Screenshot 2026-04-19 at 6 12 51 PM" src="https://github.com/user-attachments/assets/149743a9-bce5-423d-b7fa-068f97a0c442" />
