### PR TITLE
GAZ-278: Added local demo file fallback when VITE_API_URL is not set(FIXES GAZ-207).

### DIFF
--- a/public/examples/4f187905-c47e-4ebd-a095-ba254e8bfd80.json
+++ b/public/examples/4f187905-c47e-4ebd-a095-ba254e8bfd80.json
@@ -1,10 +1,7 @@
 {
   "demoName": "Batch Payments flow from PHEE - Mifos X",
   "demoDescription": "End-to-end batch payment flow from Payment Hub EE to Mifos X",
-  "tags": [
-    "MifosX",
-    "Phee"
-  ],
+  "tags": ["MifosX", "Phee"],
   "steps": {
     "1": {
       "title": "Login to Ops Web",

--- a/public/examples/4f187905-c47e-4ebd-a095-ba254e8bfd80.json
+++ b/public/examples/4f187905-c47e-4ebd-a095-ba254e8bfd80.json
@@ -1,0 +1,36 @@
+{
+  "demoName": "Batch Payments flow from PHEE - Mifos X",
+  "demoDescription": "End-to-end batch payment flow from Payment Hub EE to Mifos X",
+  "tags": [
+    "MifosX",
+    "Phee"
+  ],
+  "steps": {
+    "1": {
+      "title": "Login to Ops Web",
+      "url": "http://ops.mifos.gazelle.test",
+      "details": "Login with default credentials to access the Payment Hub EE Operations Web"
+    },
+    "2": {
+      "title": "Upload Batch CSV",
+      "url": "http://ops.mifos.gazelle.test",
+      "details": "Upload the pre-generated bulk payment CSV file for the batch transaction"
+    },
+    "3": {
+      "title": "Approve the Batch",
+      "url": "http://ops.mifos.gazelle.test",
+      "details": "Review and approve the batch payment request"
+    },
+    "4": {
+      "title": "Monitor Batch Status",
+      "url": "http://ops.mifos.gazelle.test",
+      "details": "Monitor the batch processing status until completion"
+    },
+    "5": {
+      "title": "Verify Payments in MifosX",
+      "url": "http://mifos.mifos.gazelle.test",
+      "details": "Login to MifosX and verify the payments have been received"
+    }
+  },
+  "demoId": "4f187905-c47e-4ebd-a095-ba254e8bfd80"
+}

--- a/public/examples/metadata.json
+++ b/public/examples/metadata.json
@@ -1,0 +1,21 @@
+{
+  "demos": [
+    {
+      "demoId": "4f187905-c47e-4ebd-a095-ba254e8bfd80",
+      "name": "Batch Payments flow from PHEE - Mifos X",
+      "file_name": "batch_payments_flow_from_phee__mifos_x.json",
+      "description": "End-to-end batch payment flow from Payment Hub EE to Mifos X",
+      "version": 1,
+      "steps_count": 5,
+      "created_at": "2026-04-20T09:42:33Z",
+      "updated_at": "2026-04-22T11:03:55Z",
+      "created_by": "kanishk05",
+      "last_modified_by": "kanishk05",
+      "deleted": false,
+      "tags": [
+        "MifosX",
+        "Phee"
+      ]
+    }
+  ]
+}

--- a/public/examples/metadata.json
+++ b/public/examples/metadata.json
@@ -12,10 +12,7 @@
       "created_by": "kanishk05",
       "last_modified_by": "kanishk05",
       "deleted": false,
-      "tags": [
-        "MifosX",
-        "Phee"
-      ]
+      "tags": ["MifosX", "Phee"]
     }
   ]
 }

--- a/src/lib/api/fetchDemoData.ts
+++ b/src/lib/api/fetchDemoData.ts
@@ -12,7 +12,7 @@ export const fetchDemoData = async (demotitle: string) => {
   // Fallback to local examples when VITE_API_URL is not set
   // demotitle is the demoId from the URL path
   const response = await fetch(`/examples/${demotitle}.json`, {
-    headers: { 'Accept': 'application/json' }
+    headers: { Accept: 'application/json' },
   });
   const data = await response.json();
   return data;

--- a/src/lib/api/fetchDemoData.ts
+++ b/src/lib/api/fetchDemoData.ts
@@ -1,9 +1,19 @@
 import axios from 'axios';
 
 export const fetchDemoData = async (demotitle: string) => {
-  const response = await axios.get(`${import.meta.env.VITE_API_URL}/demoData`, {
-    params: { demotitle },
+  if (import.meta.env.VITE_API_URL) {
+    const response = await axios.get(
+      `${import.meta.env.VITE_API_URL}/demoData`,
+      { params: { demotitle } }
+    );
+    return response.data;
+  }
+
+  // Fallback to local examples when VITE_API_URL is not set
+  // demotitle is the demoId from the URL path
+  const response = await fetch(`/examples/${demotitle}.json`, {
+    headers: { 'Accept': 'application/json' }
   });
-  console.log(response);
-  return response.data;
+  const data = await response.json();
+  return data;
 };

--- a/src/lib/api/fetchDemoListData.ts
+++ b/src/lib/api/fetchDemoListData.ts
@@ -1,6 +1,16 @@
 import axios from 'axios';
 
 export const fetchDemoListData = async () => {
-  const response = await axios.get(`${import.meta.env.VITE_API_URL}/demoList`);
-  return response.data.demos;
+  if (import.meta.env.VITE_API_URL) {
+    const response = await axios.get(
+      `${import.meta.env.VITE_API_URL}/demoList`
+    );
+    return response.data.demos;
+  }
+
+  // Fallback to local examples when VITE_API_URL is not set
+  const response = await axios.get('/examples/metadata.json');
+  return response.data.demos.filter(
+    (demo: { deleted: boolean }) => !demo.deleted
+  );
 };

--- a/src/pages/demo/demo-page.tsx
+++ b/src/pages/demo/demo-page.tsx
@@ -41,7 +41,7 @@ export const DemoPage = () => {
 
   useEffect(() => {
     setIsLoading(true);
-    const demoTitle = location.pathname.split('/')[3];
+    const demoTitle = location.pathname.split('/')[2];
     fetchDemoData(demoTitle)
       .then(demodatajson => {
         const steps = Object.entries(demodatajson.steps)


### PR DESCRIPTION
**problem**
The Demo Runtime had no fallback mechanism when `VITE_API_URL` was not set. This caused the demo list and individual demo pages to fail silently with no data, making it impossible to run or test demos locally without `JFrog` credentials.

**Solution**
Added local file fallback logic in `fetchDemoListData.ts` and `fetchDemoData.ts` so that when `VITE_API_URL` is not set, the app reads demo data directly from `public/examples/`.

**Changes**
`fetchDemoListData.ts`: falls back to `public/examples/metadata.json` when VITE_API_URL is not set.
`fetchDemoData.ts`:  falls back to `public/examples/{demoId}.json` when VITE_API_URL is not set.
`demo-page.tsx`: fixed URL path index from `[3] `to `[2] `to correctly extract `demoid` from the pathname, without which  no demo would load.
`public/examples/metadata.json`: added metadata index file for local demos.
`public/examples/4f187905-c47e-4ebd-a095-ba254e8bfd80.json`: added Batch Payments demo JSON for local testing.

**Testing**
Tested locally without VITE_API_URL set. Demo list loaded correctly from local metadata. The Batch Payments demo page loaded and rendered successfully.
<img width="1440" height="900" alt="Screenshot 2026-04-23 at 12 17 30 PM" src="https://github.com/user-attachments/assets/fbbdc364-c2cd-4f23-8654-f0ed8f6ae851" />
<img width="1440" height="900" alt="Screenshot 2026-04-23 at 12 17 14 PM" src="https://github.com/user-attachments/assets/57ee82d5-04cf-4e88-8cb2-4c12f6f20186" />
