### PR TITLE
GAZ-207: Added demo video link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ The Demo Runtime UI features a split-panel interface:
 
 This side-by-side layout makes it easy to follow complex workflows, as users can read instructions while performing actions in the live application simultaneously.
 
+## Demo
+
+🎥 [Watch Full Demo Video](https://drive.google.com/file/d/10WXR4D9Oxb3f_hvXF2CybZaCYl7aZUJf/view?usp=sharing)
+
+This video covers the complete end-to-end workflow — creating a demo in the TUI, publishing it with `just publish`, and viewing it live in Demo Runtime.
+
 ## Features
 
 - **Interactive Live Demos:** Engage directly with deployed DPGs in real-time

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This side-by-side layout makes it easy to follow complex workflows, as users can
 
 ## Demo
 
-🎥 [Watch Full Demo Video](https://drive.google.com/file/d/10WXR4D9Oxb3f_hvXF2CybZaCYl7aZUJf/view?usp=sharing)
+🎥 [Watch Full Demo Video](https://youtu.be/JGBA4zhxx54)
 
 This video covers the complete end-to-end workflow — creating a demo in the TUI, publishing it with `just publish`, and viewing it live in Demo Runtime.
 


### PR DESCRIPTION
**Problem**
No demo video was linked in the Demo Runtime README to show contributors and users how the tool works end-to-end.

**Solution**
Added a Demo section to the README with a link to the full end-to-end demo video showing TUI walk-through.

**Changes**
Added Demo section to README with full end-to-end video link

Demo
[Watch Full Demo Video](https://youtu.be/JGBA4zhxx54)
The video covers: launching the TUI → creating the Batch Payments demo → running just publish → viewing the demo live in Demo Runtime.